### PR TITLE
fix: sync feature/appstore-publish-migration changes and fix PostgreS…

### DIFF
--- a/.github/workflows/appstore-publish.yml
+++ b/.github/workflows/appstore-publish.yml
@@ -109,6 +109,12 @@ jobs:
             echo "seed=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Read library version
+        id: version
+        run: |
+          VERSION=$(jq -r '.Version' library.json)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Build publish artifacts
         run: |
           args=(
@@ -228,8 +234,8 @@ jobs:
         with:
           files: |
             dist/appstore-publish/legacy/release/library/library.json
-          tag_name: release-${{ github.run_number }}
-          name: Release ${{ github.run_number }}
+          tag_name: ${{ steps.version.outputs.version }}
+          name: ${{ steps.version.outputs.version }}
           draft: false
           prerelease: false
 

--- a/apps/alfresco/docker-compose.yml
+++ b/apps/alfresco/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - POSTGRES_DB=alfresco
     command: postgres -c max_connections=300 -c log_min_messages=LOG
     volumes:
-      - postgres:/var/lib/postgresql
+      - postgres:/var/lib/postgresql/data
 
   solr6:
     image: alfresco/alfresco-search-services:2.0.8.2

--- a/apps/onlyofficedocs/docker-compose.yml
+++ b/apps/onlyofficedocs/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     volumes:
       - data:/var/www/onlyoffice/Data
       - log:/var/log/onlyoffice
-      - db:/var/lib/postgresql
+      - db:/var/lib/postgresql/data
       - lib:/var/lib/onlyoffice
       - cache:/var/lib/redis
       - mq:/var/lib/rabbitmq

--- a/apps/postgresql/docker-compose.yml
+++ b/apps/postgresql/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
      - ${W9_DB_PORT_SET}:5432
     volumes:
-      - postgres:/var/lib/postgresql
+      - postgres:/var/lib/postgresql/data
     env_file: .env
     environment:
       POSTGRES_DB: ${W9_ID}

--- a/apps/safeline/.env
+++ b/apps/safeline/.env
@@ -3,7 +3,7 @@ W9_DIST='community'
 W9_VERSION='9.3.2'
 W9_POWER_PASSWORD='zWA2Ds!7R58loJrh'
 
-
+W9_HTTP_PORT=1443
 W9_HTTP_PORT_SET='9001'
 W9_ID='safeline'
 W9_DB_EXPOSE="postgresql"

--- a/build/fetch_catalog.py
+++ b/build/fetch_catalog.py
@@ -55,7 +55,6 @@ query($locale: String!, $skip: Int!, $production: Boolean) {
       description
       screenshots
       distribution
-      production
       vcpu
       memory
       storage

--- a/build/library_publish.py
+++ b/build/library_publish.py
@@ -543,10 +543,15 @@ def build_v2_appstore_artifacts(
     manifests_dir.mkdir(parents=True, exist_ok=True)
 
     catalog_sources = ensure_catalog_source(catalog_source_dir)
+    distribution_map = build_distribution_map() if channel == "dev" else {}
     catalog_checksums: dict[str, str] = {}
     for file_name, source_path in catalog_sources.items():
         destination = catalog_dir / file_name
-        shutil.copy2(source_path, destination)
+        if file_name.startswith("product_") and distribution_map:
+            product_entries = load_json(source_path)
+            write_json(destination, merge_product_distribution(product_entries, distribution_map))
+        else:
+            shutil.copy2(source_path, destination)
         if file_name == "catalog_en.json":
             catalog_checksums["catalogEn"] = write_checksum_file(destination)
         elif file_name == "catalog_zh.json":

--- a/docs/appstore-release-spec.md
+++ b/docs/appstore-release-spec.md
@@ -95,6 +95,17 @@ else:
 3. `removedApps` → 本地删除
 4. 任一 app 更新失败 → 回退到全量包恢复
 
+### 3.1 Channel 数据差异
+
+为保持与旧体系一致，`dev` 与 `release` 的数据范围**不是完全相同**：
+
+- `release`：只消费 Contentful 中 `production=true` 的 product 条目
+- `dev`：不过滤 `production`，因此包含更多 product 条目，便于开发、联调与测试
+- `dev`：额外将仓库 `apps/*/variables.json` 中的 `edition -> distribution` 信息补写回 `product_*.json`
+- `release`：不做这一步本地 distribution 补写，保持发布面向生产的数据集
+
+因此，`dev` 通道天然是"更宽、更富"的数据集，而 `release` 通道是"更收敛、更生产化"的数据集。
+
 ---
 
 ## 4. 输出物模型
@@ -246,7 +257,7 @@ artifact/appstore/<channel>/
 2. 解析 channel
 3. 检查 R2 apps/ 是否为空 → 空则标记首次发布（--all-apps）
 4. 从 Contentful 拉取 catalog 源数据
-5. 运行 library_publish.py 构建所有制品（v2 + legacy）
+5. 运行 library_publish.py 构建所有制品（v2 + legacy）；其中 dev 保留旧体系的 distribution 补写逻辑
 6. 上传 v2 制品到新 R2 路径（`channel` 只由目录表达，full 固定入口统一为 `latest.zip`）
 7. 上传 legacy 制品到旧 R2 路径（兼容旧消费者）
 8. 清除 Cloudflare 缓存

--- a/library.json
+++ b/library.json
@@ -1,13 +1,3 @@
 {
-  "Plugin Name": "library",
-  "Repository": "https://github.com/Websoft9/docker-library",
-  "Update URI": "https://example.com/my-plugin/",
-  "Description": "200 application template for you installation.",
-  "Version": "0.7.14",
-  "Requires at most": "1.5.0",
-  "Requires at least": "0.0.4",
-  "Author": "Websoft9 Inc",
-  "Author URI": "https://www.websoft9.com/",
-  "License": "GPL v2 or later",
-  "License URI": "https://www.gnu.org/licenses/gpl-2.0.html"
+  "Version": "0.8.0"
 }


### PR DESCRIPTION
…QL mount paths

- Simplify library.json to only keep Version field
- Use library.json Version as GitHub Release tag instead of run_number
- Add W9_HTTP_PORT=1443 for safeline
- Remove production field from fetch_catalog.py GraphQL query
- Add distribution merge for dev channel in library_publish.py
- Document channel data differences in appstore-release-spec.md
- Fix PostgreSQL volume mount path: /var/lib/postgresql → /var/lib/postgresql/data (postgresql, alfresco, onlyofficedocs)